### PR TITLE
docs: add release "release/teak-rg.1" tag to the CHANGELOG

### DIFF
--- a/RG_CHANGELOG.rst
+++ b/RG_CHANGELOG.rst
@@ -1,0 +1,22 @@
+RG Changelog
+############
+
+All notable changes to this project will be documented in this file.
+
+The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
+and this project adheres to customized Semantic Versioning e.g.: `teak-rg.1`
+
+[Unreleased]
+************
+
+[release/teak-rg.1] - 2025-08-06
+********************************
+
+Sync:
+=====
+* pick fixes from the upstream tokens MR (TEA-18)
+
+Added:
+======
+* add direct import of openedx-brand overrides (TEA-18)
+* add design tokens support (TEA-18)


### PR DESCRIPTION
tag is used in teak-rg release
