### PR TITLE
fix: add missing space symbol to the 'additional.help.text' field

### DIFF
--- a/src/forgot-password/ForgotPasswordPage.jsx
+++ b/src/forgot-password/ForgotPasswordPage.jsx
@@ -153,7 +153,7 @@ const ForgotPasswordPage = (props) => {
             )}
             <p className="mt-5.5 small text-gray-700">
               {formatMessage(messages['additional.help.text'], { platformName })}
-              <span>
+              <span className="mx-1">
                 <Hyperlink isInline destination={`mailto:${getConfig().INFO_EMAIL}`}>{getConfig().INFO_EMAIL}</Hyperlink>
               </span>
             </p>

--- a/src/forgot-password/messages.js
+++ b/src/forgot-password/messages.js
@@ -74,7 +74,7 @@ const messages = defineMessages({
   },
   'additional.help.text': {
     id: 'additional.help.text',
-    defaultMessage: 'For additional help, contact {platformName} support at ',
+    defaultMessage: 'For additional help, contact {platformName} support at',
     description: 'additional help text on forgot password page',
   },
   'sign.in.text': {


### PR DESCRIPTION
### Description

Backport from https://github.com/openedx/frontend-app-authn/pull/1521

[YouTrack](https://youtrack.raccoongang.com/issue/CC-79/Translations-The-space-is-missed-btw-its-a-common-bug)
