### PR TITLE
feat: [ENG-63] sync authn theme variant from shared cookie

### DIFF
--- a/RG_CHANGELOG.rst
+++ b/RG_CHANGELOG.rst
@@ -9,6 +9,10 @@ and this project adheres to customized Semantic Versioning e.g.: `teak-rg.1`
 [Unreleased]
 ************
 
+Added:
+======
+* Sync the active Paragon theme variant from the shared cross-origin ``theme-variant`` cookie (ENG-63)
+
 [release/teak-rg.3] - 2026-02-27
 ********************************
 

--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -6,7 +6,7 @@ import { Helmet } from 'react-helmet';
 import { Navigate, Route, Routes } from 'react-router-dom';
 
 import {
-  EmbeddedRegistrationRoute, NotFoundPage, registerIcons, UnAuthOnlyRoute, Zendesk,
+  EmbeddedRegistrationRoute, NotFoundPage, registerIcons, ThemeCookieSync, UnAuthOnlyRoute, Zendesk,
 } from './common-components';
 import configureStore from './data/configureStore';
 import {
@@ -33,6 +33,7 @@ registerIcons();
 
 const MainApp = () => (
   <AppProvider store={configureStore()}>
+    <ThemeCookieSync />
     <Helmet>
       <link rel="shortcut icon" href={getConfig().FAVICON_URL} type="image/x-icon" />
     </Helmet>

--- a/src/common-components/ThemeCookieSync.jsx
+++ b/src/common-components/ThemeCookieSync.jsx
@@ -1,0 +1,61 @@
+import { useContext, useEffect, useRef } from 'react';
+
+import { AppContext } from '@edx/frontend-platform/react';
+
+const readThemeCookie = () => document.cookie.match(/(?:^|;\s*)theme-variant=(dark|light)/)?.[1];
+
+/**
+ * Adopt the shared cross-origin `theme-variant` cookie as the active Paragon theme
+ * variant. The authn MFE renders its own minimal layout (logo + form) with NO shared
+ * header, so there is no <ThemeToggle/> to adopt the cookie — and frontend-platform
+ * keeps the theme choice in per-origin localStorage, which cannot be read across the
+ * MFE port boundaries. So when a user enables dark mode elsewhere (the toggle writes a
+ * shared-domain `theme-variant` cookie on `.local.openedx.io`), authn stays light unless
+ * we read that cookie here and call setThemeVariant.
+ *
+ * It also polls the cookie (and re-checks on focus/visibility) plus listens for a
+ * `{ type: 'rg-theme-variant', variant }` postMessage so a switch made in the parent
+ * window propagates LIVE — this covers the embedded registration flow (authn rendered
+ * in a cross-origin <iframe> via /register-embedded), where storage partitioning can
+ * hide the cookie from the framed page.
+ *
+ * Renders nothing; safe to mount unconditionally inside AppProvider.
+ */
+const ThemeCookieSync = () => {
+  const { paragonTheme } = useContext(AppContext);
+  const setThemeVariant = paragonTheme?.setThemeVariant;
+  const lastApplied = useRef(null);
+
+  useEffect(() => {
+    if (!setThemeVariant) { return undefined; }
+    const apply = () => {
+      const variant = readThemeCookie();
+      if (variant && variant !== lastApplied.current) {
+        lastApplied.current = variant;
+        setThemeVariant(variant);
+      }
+    };
+    const onMessage = (event) => {
+      const variant = event?.data?.type === 'rg-theme-variant' ? event.data.variant : null;
+      if ((variant === 'dark' || variant === 'light') && variant !== lastApplied.current) {
+        lastApplied.current = variant;
+        setThemeVariant(variant);
+      }
+    };
+    apply();
+    const intervalId = setInterval(apply, 1000);
+    document.addEventListener('visibilitychange', apply);
+    window.addEventListener('focus', apply);
+    window.addEventListener('message', onMessage);
+    return () => {
+      clearInterval(intervalId);
+      document.removeEventListener('visibilitychange', apply);
+      window.removeEventListener('focus', apply);
+      window.removeEventListener('message', onMessage);
+    };
+  }, [setThemeVariant]);
+
+  return null;
+};
+
+export default ThemeCookieSync;

--- a/src/common-components/index.jsx
+++ b/src/common-components/index.jsx
@@ -13,3 +13,4 @@ export { storeName } from './data/selectors';
 export { default as FormGroup } from './FormGroup';
 export { default as PasswordField } from './PasswordField';
 export { default as Zendesk } from './Zendesk';
+export { default as ThemeCookieSync } from './ThemeCookieSync';


### PR DESCRIPTION
## Description

When a user enables dark mode anywhere in the platform, that choice should
carry over to the sign-in and registration screens too. Previously the Authn
MFE always rendered in the light theme regardless of the user's preference,
because it has its own minimal layout (logo + form) with no shared header — and
therefore no theme toggle to pick up the setting. This change makes Authn read
the shared, cross-origin theme preference and render in dark mode when it's
active, including when the registration form is embedded inside another page.

## Youtrack

- https://youtrack.raccoongang.com/issue/ENG-63

## Screenshot/Video
| 1 | 2 | 3 |
|--------|--------|--------|
| <img width="3456" height="1770" alt="image" src="https://github.com/user-attachments/assets/92406677-b1e6-4793-b2ae-ffb383f088dd" /> | <img width="3456" height="1770" alt="image" src="https://github.com/user-attachments/assets/f050de91-6cf0-4573-91f2-1f48e4c41637" /> | <img width="3456" height="1770" alt="image" src="https://github.com/user-attachments/assets/92cd2c39-1a5a-47b7-8309-e33cf393983d" /> | 

## Testing

**1. Adopt theme on load (standalone Authn)**
1. As a logged-out user, enable dark mode elsewhere in the platform (e.g. via
   the shared header toggle) so the `theme-variant=dark` cookie is set.
2. Navigate directly to the Authn login or register page.
3. Expected: the page renders in the dark theme immediately on load.

**2. Live propagation while the page is open**
1. Open the Authn page in light mode.
2. In another tab/window on the same domain, switch to dark mode, then return
   focus to the Authn tab.
3. Expected: the Authn theme updates to dark without a page reload (on focus,
   or within ~1s via the cookie poll).

**3. Embedded registration (cross-origin iframe)**
1. Render `/register-embedded` inside a cross-origin iframe from a parent page.
2. Have the parent post `{ type: 'rg-theme-variant', variant: 'dark' }` to the
   iframe (e.g. on its own theme switch).
3. Expected: the embedded registration form switches to dark, even where
   storage partitioning would hide the cookie from the framed page.

**4. Light fallback / no preference**
1. Clear the `theme-variant` cookie (or set it to `light`).
2. Load the Authn page.
3. Expected: the page renders in the default light theme with no console
   errors.
