### PR TITLE
feat: [VERA-6] authn theme sync, brand fonts and own logo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,3 @@ jobs:
 
     - name: Build
       run: npm run build
-
-    - name: Run Code Coverage
-      uses: codecov/codecov-action@v5
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        fail_ci_if_error: true

--- a/RG_CHANGELOG.rst
+++ b/RG_CHANGELOG.rst
@@ -9,6 +9,10 @@ and this project adheres to customized Semantic Versioning e.g.: `verawood-rg.1`
 [Unreleased]
 ************
 
+Added:
+======
+* add custom fonts loading from rg-branding-plugin (TEA-289)
+
 Removed:
 ========
 * codecov CI action — the fork has no codecov project, so the step failed every run (VERA-6)

--- a/RG_CHANGELOG.rst
+++ b/RG_CHANGELOG.rst
@@ -1,0 +1,14 @@
+RG Changelog
+############
+
+All notable changes to this project will be documented in this file.
+
+The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
+and this project adheres to customized Semantic Versioning e.g.: `verawood-rg.1`
+
+[Unreleased]
+************
+
+Removed:
+========
+* codecov CI action — the fork has no codecov project, so the step failed every run (VERA-6)

--- a/RG_CHANGELOG.rst
+++ b/RG_CHANGELOG.rst
@@ -12,6 +12,7 @@ and this project adheres to customized Semantic Versioning e.g.: `verawood-rg.1`
 Added:
 ======
 * add custom fonts loading from rg-branding-plugin (TEA-289)
+* a separate logo for Authn via ``STUDIO_LOGO_URL``, falling back to ``LOGO_WHITE_URL`` (TEA-310)
 
 Removed:
 ========

--- a/RG_CHANGELOG.rst
+++ b/RG_CHANGELOG.rst
@@ -13,6 +13,7 @@ Added:
 ======
 * add custom fonts loading from rg-branding-plugin (TEA-289)
 * a separate logo for Authn via ``STUDIO_LOGO_URL``, falling back to ``LOGO_WHITE_URL`` (TEA-310)
+* Sync the active Paragon theme variant from the shared cross-origin ``theme-variant`` cookie (ENG-63)
 
 Removed:
 ========

--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -5,7 +5,7 @@ import { Helmet } from 'react-helmet';
 import { Navigate, Route, Routes } from 'react-router-dom';
 
 import {
-  EmbeddedRegistrationRoute, NotFoundPage, registerIcons, UnAuthOnlyRoute, Zendesk,
+  EmbeddedRegistrationRoute, NotFoundPage, registerIcons, ThemeCookieSync, UnAuthOnlyRoute, Zendesk,
 } from './common-components';
 import {
   AUTHN_PROGRESSIVE_PROFILING,
@@ -40,6 +40,7 @@ const queryClient = new QueryClient({
 const MainApp = () => (
   <QueryClientProvider client={queryClient}>
     <AppProvider>
+      <ThemeCookieSync />
       <Helmet>
         <link rel="shortcut icon" href={getConfig().FAVICON_URL} type="image/x-icon" />
       </Helmet>

--- a/src/base-container/components/default-layout/LargeLayout.jsx
+++ b/src/base-container/components/default-layout/LargeLayout.jsx
@@ -12,7 +12,11 @@ const LargeLayout = () => {
     <div className="w-50 d-flex">
       <div className="col-md-9 bg-primary-400">
         <Hyperlink destination={getConfig().MARKETING_SITE_BASE_URL}>
-          <Image className="logo position-absolute" alt={getConfig().SITE_NAME} src={getConfig().LOGO_WHITE_URL} />
+          <Image
+            className="logo position-absolute"
+            alt={getConfig().SITE_NAME}
+            src={getConfig().STUDIO_LOGO_URL || getConfig().LOGO_WHITE_URL}
+          />
         </Hyperlink>
         <div className="min-vh-100 d-flex align-items-center">
           <div className={classNames({ 'large-yellow-line mr-n4.5': getConfig().SITE_NAME === 'edX' })} />

--- a/src/base-container/components/default-layout/MediumLayout.jsx
+++ b/src/base-container/components/default-layout/MediumLayout.jsx
@@ -14,7 +14,11 @@ const MediumLayout = () => {
       <div className="w-100 p-0 mb-3 d-flex">
         <div className="col-md-10 bg-primary-400">
           <Hyperlink destination={getConfig().MARKETING_SITE_BASE_URL}>
-            <Image alt={getConfig().SITE_NAME} className="logo" src={getConfig().LOGO_WHITE_URL} />
+            <Image
+              alt={getConfig().SITE_NAME}
+              className="logo"
+              src={getConfig().STUDIO_LOGO_URL || getConfig().LOGO_WHITE_URL}
+            />
           </Hyperlink>
           <div className="d-flex align-items-center justify-content-center mb-4 ">
             <div className={classNames({ 'mt-1 medium-yellow-line': getConfig().SITE_NAME === 'edX' })} />

--- a/src/base-container/components/default-layout/SmallLayout.jsx
+++ b/src/base-container/components/default-layout/SmallLayout.jsx
@@ -13,7 +13,11 @@ const SmallLayout = () => {
       <div className="col-md-12 small-screen-top-stripe" />
       <div>
         <Hyperlink destination={getConfig().MARKETING_SITE_BASE_URL}>
-          <Image className="logo-small" alt={getConfig().SITE_NAME} src={getConfig().LOGO_WHITE_URL} />
+          <Image
+            className="logo-small"
+            alt={getConfig().SITE_NAME}
+            src={getConfig().STUDIO_LOGO_URL || getConfig().LOGO_WHITE_URL}
+          />
         </Hyperlink>
         <div className="d-flex align-items-center m-3.5">
           <div className={classNames({ 'small-yellow-line mr-n2.5': getConfig().SITE_NAME === 'edX' })} />

--- a/src/base-container/components/image-layout/ExtraSmallLayout.jsx
+++ b/src/base-container/components/image-layout/ExtraSmallLayout.jsx
@@ -15,7 +15,11 @@ const ExtraSmallLayout = () => {
       style={{ backgroundImage: `url(${getConfig().BANNER_IMAGE_EXTRA_SMALL})` }}
     >
       <Hyperlink destination={getConfig().MARKETING_SITE_BASE_URL}>
-        <Image className="company-logo" alt={getConfig().SITE_NAME} src={getConfig().LOGO_WHITE_URL} />
+        <Image
+          className="company-logo"
+          alt={getConfig().SITE_NAME}
+          src={getConfig().STUDIO_LOGO_URL || getConfig().LOGO_WHITE_URL}
+        />
       </Hyperlink>
       <div className="ml-4.5 mr-1 pb-3.5 pt-3.5">
         <h1 className="banner__heading">

--- a/src/base-container/components/image-layout/LargeLayout.jsx
+++ b/src/base-container/components/image-layout/LargeLayout.jsx
@@ -16,7 +16,11 @@ const LargeLayout = () => {
       style={{ backgroundImage: `url(${getConfig().BANNER_IMAGE_LARGE})` }}
     >
       <Hyperlink destination={getConfig().MARKETING_SITE_BASE_URL}>
-        <Image className="company-logo position-absolute" alt={getConfig().SITE_NAME} src={getConfig().LOGO_WHITE_URL} />
+        <Image
+          className="company-logo position-absolute"
+          alt={getConfig().SITE_NAME}
+          src={getConfig().STUDIO_LOGO_URL || getConfig().LOGO_WHITE_URL}
+        />
       </Hyperlink>
       <div className="min-vh-100 p-5 d-flex align-items-end">
         <h1 className="display-2 mw-sm mb-3 d-flex flex-column flex-shrink-0 justify-content-center">

--- a/src/base-container/components/image-layout/MediumLayout.jsx
+++ b/src/base-container/components/image-layout/MediumLayout.jsx
@@ -16,7 +16,11 @@ const MediumLayout = () => {
       style={{ backgroundImage: `url(${getConfig().BANNER_IMAGE_MEDIUM})` }}
     >
       <Hyperlink destination={getConfig().MARKETING_SITE_BASE_URL}>
-        <Image className="company-logo" alt={getConfig().SITE_NAME} src={getConfig().LOGO_WHITE_URL} />
+        <Image
+          className="company-logo"
+          alt={getConfig().SITE_NAME}
+          src={getConfig().STUDIO_LOGO_URL || getConfig().LOGO_WHITE_URL}
+        />
       </Hyperlink>
       <div className="ml-5 pb-4 pt-4">
         <h1 className="display-2 banner__heading">

--- a/src/base-container/components/image-layout/SmallLayout.jsx
+++ b/src/base-container/components/image-layout/SmallLayout.jsx
@@ -15,7 +15,11 @@ const SmallLayout = () => {
       style={{ backgroundImage: `url(${getConfig().BANNER_IMAGE_SMALL})` }}
     >
       <Hyperlink destination={getConfig().MARKETING_SITE_BASE_URL}>
-        <Image className="company-logo" alt={getConfig().SITE_NAME} src={getConfig().LOGO_WHITE_URL} />
+        <Image
+          className="company-logo"
+          alt={getConfig().SITE_NAME}
+          src={getConfig().STUDIO_LOGO_URL || getConfig().LOGO_WHITE_URL}
+        />
       </Hyperlink>
       <div className="ml-5 mr-1 pb-3.5 pt-3.5">
         <h1 className="display-2">

--- a/src/common-components/ThemeCookieSync.jsx
+++ b/src/common-components/ThemeCookieSync.jsx
@@ -1,0 +1,61 @@
+import { useContext, useEffect, useRef } from 'react';
+
+import { AppContext } from '@edx/frontend-platform/react';
+
+const readThemeCookie = () => document.cookie.match(/(?:^|;\s*)theme-variant=(dark|light)/)?.[1];
+
+/**
+ * Adopt the shared cross-origin `theme-variant` cookie as the active Paragon theme
+ * variant. The authn MFE renders its own minimal layout (logo + form) with NO shared
+ * header, so there is no <ThemeToggle/> to adopt the cookie — and frontend-platform
+ * keeps the theme choice in per-origin localStorage, which cannot be read across the
+ * MFE port boundaries. So when a user enables dark mode elsewhere (the toggle writes a
+ * shared-domain `theme-variant` cookie on `.local.openedx.io`), authn stays light unless
+ * we read that cookie here and call setThemeVariant.
+ *
+ * It also polls the cookie (and re-checks on focus/visibility) plus listens for a
+ * `{ type: 'rg-theme-variant', variant }` postMessage so a switch made in the parent
+ * window propagates LIVE — this covers the embedded registration flow (authn rendered
+ * in a cross-origin <iframe> via /register-embedded), where storage partitioning can
+ * hide the cookie from the framed page.
+ *
+ * Renders nothing; safe to mount unconditionally inside AppProvider.
+ */
+const ThemeCookieSync = () => {
+  const { paragonTheme } = useContext(AppContext);
+  const setThemeVariant = paragonTheme?.setThemeVariant;
+  const lastApplied = useRef(null);
+
+  useEffect(() => {
+    if (!setThemeVariant) { return undefined; }
+    const apply = () => {
+      const variant = readThemeCookie();
+      if (variant && variant !== lastApplied.current) {
+        lastApplied.current = variant;
+        setThemeVariant(variant);
+      }
+    };
+    const onMessage = (event) => {
+      const variant = event?.data?.type === 'rg-theme-variant' ? event.data.variant : null;
+      if ((variant === 'dark' || variant === 'light') && variant !== lastApplied.current) {
+        lastApplied.current = variant;
+        setThemeVariant(variant);
+      }
+    };
+    apply();
+    const intervalId = setInterval(apply, 1000);
+    document.addEventListener('visibilitychange', apply);
+    window.addEventListener('focus', apply);
+    window.addEventListener('message', onMessage);
+    return () => {
+      clearInterval(intervalId);
+      document.removeEventListener('visibilitychange', apply);
+      window.removeEventListener('focus', apply);
+      window.removeEventListener('message', onMessage);
+    };
+  }, [setThemeVariant]);
+
+  return null;
+};
+
+export default ThemeCookieSync;

--- a/src/common-components/index.jsx
+++ b/src/common-components/index.jsx
@@ -10,3 +10,4 @@ export { RenderInstitutionButton } from './InstitutionLogistration';
 export { default as FormGroup } from './FormGroup';
 export { default as PasswordField } from './PasswordField';
 export { default as Zendesk } from './Zendesk';
+export { default as ThemeCookieSync } from './ThemeCookieSync';

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -4,14 +4,16 @@ import 'regenerator-runtime/runtime';
 import { StrictMode } from 'react';
 
 import {
-  APP_INIT_ERROR, APP_READY, initialize, mergeConfig, subscribe,
+  APP_CONFIG_INITIALIZED, APP_INIT_ERROR, APP_READY, getConfig, initialize, mergeConfig, subscribe,
 } from '@edx/frontend-platform';
+import { loadExternalScripts } from '@edx/frontend-platform/initialize';
 import { ErrorPage } from '@edx/frontend-platform/react';
 import { createRoot } from 'react-dom/client';
 
 import configuration from './config';
 import messages from './i18n';
 import MainApp from './MainApp';
+import { BrandingFontLoader } from './services';
 
 subscribe(APP_READY, () => {
   const root = createRoot(document.getElementById('root'));
@@ -33,10 +35,20 @@ subscribe(APP_INIT_ERROR, (error) => {
   );
 });
 
+subscribe(APP_CONFIG_INITIALIZED, () => {
+  loadExternalScripts([BrandingFontLoader], {
+    config: getConfig(),
+  });
+});
+
 initialize({
   handlers: {
     config: () => {
-      mergeConfig(configuration);
+      mergeConfig({
+        ...configuration,
+        GOOGLE_FONTS: process.env.GOOGLE_FONTS || '',
+        CUSTOM_FONTS: process.env.CUSTOM_FONTS || '',
+      });
     },
   },
   messages,

--- a/src/services/BrandingFontLoader.js
+++ b/src/services/BrandingFontLoader.js
@@ -1,0 +1,71 @@
+/**
+ * @implements {BrandingFontLoader}
+ * @memberof module:FontLoaderScript
+ */
+class BrandingFontLoader {
+  constructor({ config }) {
+    this.googleFontsUrl = config.GOOGLE_FONTS;
+    this.customFonts = config.CUSTOM_FONTS;
+  }
+
+  loadGoogleFonts() {
+    if (!this.googleFontsUrl) {
+      return;
+    }
+
+    // Avoid inserting duplicates
+    if (document.querySelector('link[data-font-loader="google-font"]')) {
+      return;
+    }
+
+    const preconnect1 = document.createElement('link');
+    preconnect1.rel = 'preconnect';
+    preconnect1.href = 'https://fonts.googleapis.com';
+    preconnect1.setAttribute('data-font-loader', 'google-font');
+
+    const preconnect2 = document.createElement('link');
+    preconnect2.rel = 'preconnect';
+    preconnect2.href = 'https://fonts.gstatic.com';
+    preconnect2.crossOrigin = 'anonymous';
+    preconnect2.setAttribute('data-font-loader', 'google-font');
+
+    const stylesheet = document.createElement('link');
+    stylesheet.rel = 'stylesheet';
+    stylesheet.href = this.googleFontsUrl;
+    stylesheet.setAttribute('data-font-loader', 'google-font');
+
+    document.head.append(preconnect1, preconnect2, stylesheet);
+  }
+
+  loadCustomFonts() {
+    if (!Array.isArray(this.customFonts) || this.customFonts.length === 0) {
+      return;
+    }
+
+    // Avoid duplicate injection
+    if (document.getElementById('custom-fonts-style')) {
+      return;
+    }
+
+    const style = document.createElement('style');
+    style.id = 'custom-fonts-style';
+
+    style.innerHTML = this.customFonts.map(font => `
+      @font-face {
+        font-family: '${font.font_family}';
+        src: url('${font.font_file}') format('woff2');
+        font-weight: ${font.font_weight};
+        font-style: ${font.font_style};
+        font-display: swap;
+      }
+    `).join('\n');
+    document.head.appendChild(style);
+  }
+
+  loadScript() {
+    this.loadGoogleFonts();
+    this.loadCustomFonts();
+  }
+}
+
+export default BrandingFontLoader;

--- a/src/services/BrandingFontLoader.test.js
+++ b/src/services/BrandingFontLoader.test.js
@@ -1,0 +1,109 @@
+import BrandingFontLoader from './BrandingFontLoader';
+
+describe('BrandingFontLoader', () => {
+  beforeEach(() => {
+    document.head.innerHTML = ''; // clean head before each test
+  });
+
+  test('should inject Google Fonts <link> tags when GOOGLE_FONTS is set', () => {
+    const loader = new BrandingFontLoader({
+      config: {
+        GOOGLE_FONTS: 'https://fonts.googleapis.com/css2?family=Roboto&display=swap',
+      },
+    });
+
+    loader.loadScript();
+
+    const links = document.querySelectorAll('link[data-font-loader="google-font"]');
+    expect(links.length).toBe(3);
+    expect(document.querySelector(`link[href="${loader.googleFontsUrl}"]`)).toBeTruthy();
+  });
+
+  test('should not inject Google Fonts if already present', () => {
+    const link = document.createElement('link');
+    link.setAttribute('data-font-loader', 'google-font');
+    document.head.appendChild(link);
+
+    const loader = new BrandingFontLoader({
+      config: { GOOGLE_FONTS: 'https://fonts.googleapis.com/css2?family=Roboto&display=swap' },
+    });
+
+    loader.loadScript();
+
+    const links = document.querySelectorAll('link[data-font-loader="google-font"]');
+    expect(links.length).toBe(1); // no duplicates
+  });
+
+  test('should inject <style> with @font-face rules when CUSTOM_FONTS is set', () => {
+    const loader = new BrandingFontLoader({
+      config: {
+        CUSTOM_FONTS: [
+          {
+            font_family: 'CustomFont',
+            font_file: 'https://example.com/font.woff2',
+            font_weight: '400',
+            font_style: 'normal',
+          },
+        ],
+      },
+    });
+
+    loader.loadScript();
+
+    const style = document.getElementById('custom-fonts-style');
+    expect(style).toBeTruthy();
+    expect(style.innerHTML).toContain('@font-face');
+    expect(style.innerHTML).toContain("font-family: 'CustomFont'");
+  });
+
+  test('should not inject @font-face if CUSTOM_FONTS is empty', () => {
+    const loader = new BrandingFontLoader({ config: { CUSTOM_FONTS: [] } });
+    loader.loadScript();
+    expect(document.getElementById('custom-fonts-style')).toBeNull();
+  });
+
+  test('should not inject duplicate @font-face style tag', () => {
+    const style = document.createElement('style');
+    style.id = 'custom-fonts-style';
+    document.head.appendChild(style);
+
+    const loader = new BrandingFontLoader({
+      config: {
+        CUSTOM_FONTS: [
+          {
+            font_family: 'TestFont',
+            font_file: 'https://example.com/font.woff2',
+            font_weight: '400',
+            font_style: 'normal',
+          },
+        ],
+      },
+    });
+
+    loader.loadScript();
+
+    // should remain only one
+    expect(document.querySelectorAll('#custom-fonts-style').length).toBe(1);
+  });
+
+  test('should work when both GOOGLE_FONTS and CUSTOM_FONTS are set', () => {
+    const loader = new BrandingFontLoader({
+      config: {
+        GOOGLE_FONTS: 'https://fonts.googleapis.com/css2?family=Roboto&display=swap',
+        CUSTOM_FONTS: [
+          {
+            font_family: 'DualFont',
+            font_file: 'https://example.com/dual.woff2',
+            font_weight: '700',
+            font_style: 'italic',
+          },
+        ],
+      },
+    });
+
+    loader.loadScript();
+
+    expect(document.querySelectorAll('link[data-font-loader="google-font"]').length).toBe(3);
+    expect(document.getElementById('custom-fonts-style')).toBeTruthy();
+  });
+});

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,0 +1,1 @@
+export { default as BrandingFontLoader } from './BrandingFontLoader';


### PR DESCRIPTION
## Description

The sign-in and registration pages render their own minimal layout with no shared header or footer, which quietly left them outside three things every other page gets. They ignored the reader's light/dark choice, so someone who had turned on dark mode elsewhere still landed on a bright white sign-in page. They loaded no brand fonts, so the type did not match the rest of the site. And they could not show a sign-in-specific logo.

This change fixes all three, and drops a CI step that failed on every run. It re-establishes the RaccoonGang fork of this MFE on the Verawood release line, carrying only what is still needed — two of the six candidate changes are already in upstream Verawood and were deliberately left out.

## Youtrack

- https://youtrack.raccoongang.com/issue/VERA-6

## Testing

1. **Dark theme adopted from the shared cookie**
   - Preconditions: theme mode `both`; a shared-domain `theme-variant` cookie (e.g. on `.local.openedx.io`).
   - Actions: turn on dark mode on any other page, then open `/login` in a new tab.
   - Expected: the sign-in page renders dark. Note authn has no toggle of its own, so before this change it stayed light regardless.

2. **Live propagation into an open tab**
   - Actions: leave `/login` open, switch the theme on a legacy LMS page in another tab, return to `/login` without reloading.
   - Expected: authn follows within about a second — the component polls the cookie and also re-checks on focus and visibility change.

3. **Embedded registration flow**
   - Preconditions: `/register-embedded` rendered inside a cross-origin iframe.
   - Actions: switch the theme in the parent window.
   - Expected: the framed page follows via the `rg-theme-variant` postMessage, which covers the case where storage partitioning hides the cookie from the iframe.

4. **Separate Authn logo**
   - Preconditions: set `MFE_CONFIG["STUDIO_LOGO_URL"]` to a distinct image.
   - Actions: view `/login` and `/register` at desktop, tablet and mobile widths, in both the default and image layouts.
   - Expected: all seven layouts show the `STUDIO_LOGO_URL` image. With the key unset, every layout falls back to `LOGO_WHITE_URL` and looks exactly as before.

5. **Brand fonts**
   - Preconditions: set `MFE_CONFIG["CUSTOM_FONTS"]` and/or `["GOOGLE_FONTS"]`.
   - Actions: open `/login` and inspect `<head>`.
   - Expected: `<style id="custom-fonts-style">` with the `@font-face` rules, and/or the Google Fonts `<link>` plus its two preconnects tagged `data-font-loader="google-font"`. Reload and confirm nothing is injected twice — both loaders guard against duplicates.

6. **Regression: no cookie / malformed cookie**
   - Actions: clear cookies and open `/login`; then set `theme-variant=bogus` and reload.
   - Expected: light theme in both cases and no console error. The cookie is matched strictly against `dark|light`.

7. **Regression: unconfigured deployment**
   - Preconditions: none of `STUDIO_LOGO_URL`, `GOOGLE_FONTS`, `CUSTOM_FONTS` set — the current default.
   - Actions: exercise sign-in, registration, forgot-password and reset-password.
   - Expected: identical to `verawood-rg`. No fonts injected, logo falls back, no errors.

8. **CI**
   - Expected: the `tests` job ends after `npm run build` with no Code Coverage step, so it no longer fails on the missing `CODECOV_TOKEN`.
